### PR TITLE
Add pydantic-settings dependency and configuration

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,10 +1,12 @@
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
     ENVIRONMENT: Literal["development", "production", "test"] = Field(
         default="development", description="Runtime environment label"
     )
@@ -14,11 +16,6 @@ class Settings(BaseSettings):
         default=None,
         description="Optional OpenAI API key used for narrative generation",
     )
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-
 
 @lru_cache
 def get_settings() -> Settings:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.11"
 fastapi = "^0.110.0"
 uvicorn = {extras = ["standard"], version = "^0.29.0"}
 pydantic = "^2.6.4"
+pydantic-settings = "^2.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"


### PR DESCRIPTION
## Summary
- add the pydantic-settings dependency to the backend poetry configuration
- update the FastAPI settings module to import BaseSettings from pydantic-settings and use the v2 configuration style

## Testing
- `poetry lock` *(fails: cannot reach pypi.org from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6242400ec832abb3652fc8a824610